### PR TITLE
Optimize Int::asBin

### DIFF
--- a/src/main/kotlin/me/jacoblewis/bitwise/Utils.kt
+++ b/src/main/kotlin/me/jacoblewis/bitwise/Utils.kt
@@ -3,20 +3,9 @@ package me.jacoblewis.bitwise
 val Int.asBin: String
     get() {
         val n = this
-        val maxNum = when {
-            n == Int.MIN_VALUE -> 31
-            (n xor 0x1) + n == 0x1 -> 0
-            (n xor 0xf) + n == 0xf -> 3
-            (n xor 0xff) + n == 0xff -> 7
-            (n xor 0xfff) + n == 0xfff -> 11
-            (n xor 0xffff) + n == 0xffff -> 15
-            (n xor 0xfffff) + n == 0xfffff -> 19
-            (n xor 0xffffff) + n == 0xffffff -> 23
-            (n xor 0xfffffff) + n == 0xfffffff -> 27
-            (n xor 0x7fffffff) + n == 0x7fffffff -> 31
-            else -> 0
-        }
-        return (maxNum downTo 0).fold("") { acc, i ->
+        val minBitCount = 32 - n.countLeadingZeroBits()
+        val maxBit = 3 + ((minBitCount ushr 2) shl 2)
+        return (maxBit downTo 0).fold("") { acc, i ->
             acc + (if ((n ushr i) and 1 == 1) "1" else "0") + if (i % 4 == 0 && i != 0) " " else ""
         }
     }


### PR DESCRIPTION
Optimize bit counting in `Int::asBin` using bit shifting and `Int::countLeadingZeroBits()` (which also uses bit shifting in a cleaver way)